### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ How to build:
 * Method One:
   1. $ repo init -u https://github.com/STMicroelectronics/oe-manifest.git -b refs/tags/openstlinux-5.10-dunfell-mp1-21-03-31
   2. $ repo sync
-  3. $ git clone git@github.com:Seeed-Studio/meta-st-odyssey.git
+  3. $ git clone https://github.com/Seeed-Studio/meta-st-odyssey.git
   4. $ DISTRO=openstlinux-weston MACHINE=stm32mp1 source layers/meta-st/scripts/envsetup.sh
   5. $ bitbake-layers add-layer ../meta-st-odyssey
   6. $ bitbake st-image-weston


### PR DESCRIPTION
git clone with "git@" fails due to lack of credentials.
git clone with "https://" SUCCEEDS.